### PR TITLE
Fix modal background color

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -449,7 +449,7 @@ body{
 }
 
 .modal, .modal-content{
-	background-color: var(--background-transp);
+	background-color: var(--background-blurred);
 	backdrop-filter: var(--blur-effect);
 }
 .mod-confirmation > .modal, /*Fix for small modals (e.g. select font)*/


### PR DESCRIPTION
`background-transp` made the Workspaces pop-up menu transparent, changed it to `background-blurred` like on the Command Palette to fix this.

![image](https://github.com/oqipoDev/Buena-Vista-Theme/assets/80261260/fe771a2f-fbc3-4b51-a5dc-db62cca0b792)